### PR TITLE
Fix measurement unit overlap with abbreviation

### DIFF
--- a/src/somajo/data/abbreviations_de.txt
+++ b/src/somajo/data/abbreviations_de.txt
@@ -1228,3 +1228,31 @@ zzt.
 Übk.
 übl.
 üblw.
+
+# custom additions
+# https://de.wikipedia.org/wiki/Abk%C3%BCrzungen/Gesetze_und_Recht
+# https://de.wikipedia.org/wiki/Liste_von_Listen_von_Abk%C3%BCrzungen
+# http://personal.kent.edu/~gkoby/GermanAbbreviations/
+GBl.
+S.
+GV.NRW.
+GV.NW.
+B.Sc.
+M.Sc.
+B.A.
+M.A.
+B.Eng.
+M.Eng.
+LL.B.
+LL.M.
+B.F.A.
+M.F.A.
+B.Mus.
+M.Mus.
+B.Ed.
+M.Ed.
+Bundesgesetzbl.
+NRW.
+GMBl.
+BStBl.
+BAnz.

--- a/src/somajo/data/abbreviations_de.txt
+++ b/src/somajo/data/abbreviations_de.txt
@@ -1252,6 +1252,7 @@ M.Mus.
 B.Ed.
 M.Ed.
 Bundesgesetzbl.
+Reichtsgesetzbl.
 NRW.
 GMBl.
 BStBl.

--- a/src/somajo/data/abbreviations_de.txt
+++ b/src/somajo/data/abbreviations_de.txt
@@ -1252,7 +1252,7 @@ M.Mus.
 B.Ed.
 M.Ed.
 Bundesgesetzbl.
-Reichtsgesetzbl.
+Reichsgesetzbl.
 NRW.
 GMBl.
 BStBl.

--- a/src/somajo/tokenizer.py
+++ b/src/somajo/tokenizer.py
@@ -362,7 +362,7 @@ class Tokenizer():
         self.amount = re.compile(r'(?<!\w)(?:\d+[\d,.]*[,.]-)(?!\w)')
         self.semester = re.compile(r'(?<!\w)(?P<a_semester>[WS]S|SoSe|WiSe)(?P<b_jahr>\d\d(?:/\d\d)?)(?!\w)', re.IGNORECASE)
         units = utils.read_abbreviation_file("units.txt")
-        self.measurement = re.compile(r"(?<!\w|\d[.,]?)" + f"(?:{number}|{number_range})[ ]?" + r"(?P<unit>" + r"|".join([re.escape(_) for _ in units]) + ")" + r"(?!\w)", re.IGNORECASE | re.VERBOSE)
+        self.measurement = re.compile(r"(?<!\w|\d[.,]?)" + f"(?:{number}|{number_range})[ ]?" + r"(?P<unit>" + r"|".join([re.escape(_) for _ in units]) + ")" + r"(?![\w.])", re.IGNORECASE | re.VERBOSE)
         self.number_compound = re.compile(r'(?<!\w-?) (?:\d+-?[\p{L}@][\p{L}@-]*) (?!\w)', re.VERBOSE)
         self.number = re.compile(r"(?<!\w-?|\d[.,]?)" + number + r"(?![.,]?\d)", re.VERBOSE)
         self.ipv4 = re.compile(r"(?<!\w|\d[.,]?)(?:\d{1,3}[.]){3}\d{1,3}(?![.,]?\d)")


### PR DESCRIPTION
This pull request fixes an issue with overlapping tokens in [tokenizer.py](https://github.com/tsproisl/SoMaJo/blob/master/src/somajo/tokenizer.py#L365). The issue is that the tokenizer first splits on [all measurement units](https://github.com/tsproisl/SoMaJo/blob/master/src/somajo/tokenizer.py#L755) and afterwards [on abbreviations](https://github.com/tsproisl/SoMaJo/blob/master/src/somajo/tokenizer.py#L758). However in the case of overlap between *measurement units* and *abbreviations* e.g. due to custom additions to the [units.txt](https://github.com/tsproisl/SoMaJo/blob/master/src/somajo/data/units.txt) or [abbreviations.txt](https://github.com/tsproisl/SoMaJo/blob/master/src/somajo/data/abbreviations_de.txt), the abbreviation cannot be handled anymore.  
Concrete example:
```
In Abs. 2 S. 4 beschreibt der Autor das Balzverhalten von Einhörnern.
```
Conflicts between custom abbreviation for sentence references `S.` and unit `s` (seconds). 
Similar conflicts may arise for all other units that may double as abbreviation and appear in the context of digits or numbers. Since no unit in [units.txt](https://github.com/tsproisl/SoMaJo/blob/master/src/somajo/data/units.txt) has a dot `.` as suffix, we can use a negative dot lookahead to differentiate between units and abbreviations and resolve such conflicts. This will break if units with a dot get added to the units file, but to my knowledge that scenario is unlikely (but should be documented somewhere).